### PR TITLE
Ignore choco exit code 3010

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ build_script:
   - ps: choco pack
 
 test_script:
-  - choco install vmwareworkstation
   - ps: .\test.ps1
 
 deploy_script:

--- a/test.ps1
+++ b/test.ps1
@@ -5,7 +5,7 @@ if ($env:APPVEYOR_BUILD_VERSION) {
   $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$')
 
   # install VMware Workstation first
-  choco install -y vmwareworkstation
+  choco install -y vmwareworkstation --version=15.0.3
 } else {
   # run manually
   [xml]$spec = Get-Content vagrant-vmware-utility.nuspec

--- a/test.ps1
+++ b/test.ps1
@@ -3,6 +3,9 @@ $ErrorActionPreference = "Stop"
 if ($env:APPVEYOR_BUILD_VERSION) {
   # run in CI
   $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$')
+
+  # install VMware Workstation first
+  choco install -y vmwareworkstation
 } else {
   # run manually
   [xml]$spec = Get-Content vagrant-vmware-utility.nuspec


### PR DESCRIPTION
When installing the choco package vmwareworkstation it exits with 3010 and aborts the further tests in AppVeyor.
Let's try to fix this. We don't care of that reboot suggestion, we only want to have the software installed to do an installation test of the vagrant-vmware-utility.
